### PR TITLE
Fix message post init methods to accept already decoded types

### DIFF
--- a/buttplug/messages/v0.py
+++ b/buttplug/messages/v0.py
@@ -48,7 +48,8 @@ class Error(Incoming):
     error_code: ErrorCode
 
     def __post_init__(self):
-        self.error_code = ErrorCode(self.error_code)
+        if not isinstance(self.error_code, ErrorCode):
+            self.error_code = ErrorCode(self.error_code)
 
 
 @dataclass
@@ -75,7 +76,8 @@ class ServerInfo(Incoming):
     max_ping_time: int
 
     def __post_init__(self):
-        self.message_version = ProtocolSpec(self.message_version)
+        if not isinstance(self.message_version, ProtocolSpec):
+            self.message_version = ProtocolSpec(self.message_version)
 
 
 ###############################################################################
@@ -114,7 +116,10 @@ class DeviceList(Incoming):
     devices: list[Union[Device, dict]]
 
     def __post_init__(self):
-        self.devices = [Device(**args) for args in self.devices]
+        self.devices = [
+            device if isinstance(device, Device) else Device(**device)
+            for device in self.devices
+        ]
 
 
 @dataclass

--- a/buttplug/messages/v1.py
+++ b/buttplug/messages/v1.py
@@ -55,8 +55,10 @@ class Device(Field):
     device_messages: dict[str, Union[DeviceMessageAttributes, dict]]
 
     def __post_init__(self):
-        self.device_messages = {key: DeviceMessageAttributes(**args)
-                                for key, args in self.device_messages.items()}
+        self.device_messages = {
+            key: attrs if isinstance(attrs, DeviceMessageAttributes) else DeviceMessageAttributes(**attrs)
+            for key, attrs in self.device_messages.items()
+        }
 
 
 @dataclass
@@ -64,7 +66,10 @@ class DeviceList(Incoming):
     devices: list[Union[Device, dict]]
 
     def __post_init__(self):
-        self.devices = [Device(**args) for args in self.devices]
+        self.devices = [
+            device if isinstance(device, Device) else Device(**device)
+            for device in self.devices
+        ]
 
 
 @dataclass
@@ -74,8 +79,10 @@ class DeviceAdded(Incoming):
     device_messages: dict[str, Union[DeviceMessageAttributes, dict]]
 
     def __post_init__(self):
-        self.device_messages = {key: DeviceMessageAttributes(**args)
-                                for key, args in self.device_messages.items()}
+        self.device_messages = {
+            key: attrs if isinstance(attrs, DeviceMessageAttributes) else DeviceMessageAttributes(**attrs)
+            for key, attrs in self.device_messages.items()
+        }
 
 
 ###############################################################################
@@ -97,7 +104,10 @@ class VibrateCmd(Outgoing):
     speeds: list[Union[Speed, dict]]
 
     def __post_init__(self):
-        self.speeds = [Speed(**args) for args in self.speeds]
+        self.speeds = [
+            speed if isinstance(speed, Speed) else Speed(**speed)
+            for speed in self.speeds
+        ]
 
 
 @dataclass
@@ -113,7 +123,10 @@ class LinearCmd(Outgoing):
     vectors: list[Union[Vector, dict]]
 
     def __post_init__(self):
-        self.vectors = [Vector(**args) for args in self.vectors]
+        self.vectors = [
+            vector if isinstance(vector, Vector) else Vector(**vector)
+            for vector in self.vectors
+        ]
 
 
 @dataclass
@@ -129,7 +142,10 @@ class RotateCmd(Outgoing):
     rotations: list[Union[Rotation, dict]]
 
     def __post_init__(self):
-        self.rotations = [Rotation(**args) for args in self.rotations]
+        self.rotations = [
+            rotation if isinstance(rotation, Rotation) else Rotation(**rotation)
+            for rotation in self.rotations
+        ]
 
 
 ###############################################################################

--- a/buttplug/messages/v2.py
+++ b/buttplug/messages/v2.py
@@ -38,7 +38,8 @@ class ServerInfo(Incoming):
     max_ping_time: int
 
     def __post_init__(self):
-        self.message_version = ProtocolSpec(self.message_version)
+        if not isinstance(self.message_version, ProtocolSpec):
+            self.message_version = ProtocolSpec(self.message_version)
 
 
 ###############################################################################
@@ -58,8 +59,10 @@ class Device(Field):
     device_messages: dict[str, Union[DeviceMessageAttributes, dict]]
 
     def __post_init__(self):
-        self.device_messages = {key: DeviceMessageAttributes(**args)
-                                for key, args in self.device_messages.items()}
+        self.device_messages = {
+            key: attrs if isinstance(attrs, DeviceMessageAttributes) else DeviceMessageAttributes(**attrs)
+            for key, attrs in self.device_messages.items()
+        }
 
 
 @dataclass
@@ -67,7 +70,10 @@ class DeviceList(Incoming):
     devices: list[Union[Device, dict]]
 
     def __post_init__(self):
-        self.devices = [Device(**args) for args in self.devices]
+        self.devices = [
+            device if isinstance(device, Device) else Device(**device)
+            for device in self.devices
+        ]
 
 
 @dataclass
@@ -77,8 +83,10 @@ class DeviceAdded(Incoming):
     device_messages: dict[str, Union[DeviceMessageAttributes, dict]]
 
     def __post_init__(self):
-        self.device_messages = {key: DeviceMessageAttributes(**args)
-                                for key, args in self.device_messages.items()}
+        self.device_messages = {
+            key: attrs if isinstance(attrs, DeviceMessageAttributes) else DeviceMessageAttributes(**attrs)
+            for key, attrs in self.device_messages.items()
+        }
 
 
 ###############################################################################

--- a/buttplug/messages/v3.py
+++ b/buttplug/messages/v3.py
@@ -57,8 +57,10 @@ class Device(Field):
 
     def __post_init__(self):
         self.device_messages = {
-            key: [DeviceMessageAttributes(**d) for d in l]
-            for key, l in self.device_messages.items()
+            key: [
+                attrs if isinstance(attrs, DeviceMessageAttributes) else DeviceMessageAttributes(**attrs)
+                for attrs in message_attributes
+            ] for key, message_attributes in self.device_messages.items()
         }
 
 
@@ -67,7 +69,10 @@ class DeviceList(Incoming):
     devices: list[Union[Device, dict]]
 
     def __post_init__(self):
-        self.devices = [Device(**args) for args in self.devices]
+        self.devices = [
+            device if isinstance(device, Device) else Device(**device)
+            for device in self.devices
+        ]
 
 
 @dataclass
@@ -80,8 +85,10 @@ class DeviceAdded(Incoming):
 
     def __post_init__(self):
         self.device_messages = {
-            key: [DeviceMessageAttributes(**d) for d in l]
-            for key, l in self.device_messages.items()
+            key: [
+                attrs if isinstance(attrs, DeviceMessageAttributes) else DeviceMessageAttributes(**attrs)
+                for attrs in message_attributes
+            ] for key, message_attributes in self.device_messages.items()
         }
 
 
@@ -105,7 +112,10 @@ class ScalarCmd(Outgoing):
     scalars: list[Union[Scalar, dict]]
 
     def __post_init__(self):
-        self.scalars = [Scalar(**args) for args in self.scalars]
+        self.scalars = [
+            scalar if isinstance(scalar, Scalar) else Scalar(**scalar)
+            for scalar in self.scalars
+        ]
 
 
 ###############################################################################


### PR DESCRIPTION
Messages post init method converts some attributes from python built in types (from the JSON decoding) into library types, but if those types were being provided to the constructors, they errored out.