### PR TITLE
Client connection API imprevement

### DIFF
--- a/buttplug/errors/__init__.py
+++ b/buttplug/errors/__init__.py
@@ -1,6 +1,7 @@
 from .base import ButtplugError
 from .client import \
     ClientError, \
+    ReconnectError, \
     ScanNotRunningError, \
     UnsupportedCommandError, \
     UnexpectedMessageError, \
@@ -23,6 +24,7 @@ __all__ = (
     'ButtplugError',
 
     'ClientError',
+    'ReconnectError',
     'ScanNotRunningError',
     'UnsupportedCommandError',
     'UnexpectedMessageError',

--- a/buttplug/errors/client.py
+++ b/buttplug/errors/client.py
@@ -9,6 +9,13 @@ class ClientError(ButtplugError):
         super().__init__(message)
 
 
+class ReconnectError(ClientError):
+    """Trying to reconnect without a connector."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"Client '{name}' tried to reconnect without a connector")
+
+
 class ScanNotRunningError(ClientError):
     """Stop scan attempted while not running any."""
 


### PR DESCRIPTION
`client.reconnect()` allows to connect again using the same connector. It raises an exception if you try to reconnect without a connector provided by a previous `client.connect` call.

`client.connected` exposes the connector status as a boolean, to prevent the need of holding a reference to the connector after you provided it to the client.